### PR TITLE
feat: Add Disclosure Immunefi

### DIFF
--- a/disclosures/2023-04-04.md
+++ b/disclosures/2023-04-04.md
@@ -1,0 +1,75 @@
+# Incident disclosure - 2023-04-04
+
+## Summary
+
+- On April 4th 2023, a security researcher [[1]](#References) disclosed a bug in the `StrategystETHAccumulator_v2` strategy through Immunefi. **Funds are safe, there were no losses.**
+- While the issue in the code had the potential to create accounting discrepancies, the vault and strategy contained multiple safeguard mechanisms that prevented the loss of funds in most instances, typically by reverting the transaction
+- The impacted strategy continues to function without interruption, and a corrected contract is set to be deployed in the near future.
+
+## Background
+
+Whitehat submits a report via Immunefi about a bug in the `StrategystETHAccumulator_v2` code which could potentially lead to an error in the accounting logic. Although the bug was thoroughly described, the report lacked a proof of concept (POC).
+
+Upon receiving the report, Immunefi promptly triaged the issue and forwarded it to Yearn's security team for further investigation. The team wasted no time in analyzing the information provided in the report and ultimately confirmed its accuracy, deeming the issue to have a low impact and likelihood.
+
+The identified issue pertains to the `StrategystETHAccumulator_v2` contract[[2]](#References), which stakes ETH on Lido Finance [[3]](#References) in order to mint stETH and accumulates ETH 2.0 staking rewards.
+
+## Details of Incident
+
+The `StrategystETHAccumulator_v2` strategy code contains a flaw in calculating the loss within the `prepareReturn()` method. This method is responsible for notifying the vault of profit, loss, and debt payment incurred by the Strategy. The issue arises specifically when the Strategy's total assets exceed its debt and the loss is greater than the profit.
+
+The logic error is present in the following code segment:
+
+```solidity
+else {
+    _profit = 0;
+    _loss = _loss - _profit;
+}
+```
+
+In this specific scenario, `_profit` is assigned a value of zero, and subsequently, `_loss` is calculated using the expression `_loss = _loss - _profit`. This computation is incorrect, as it fails to account for the profit realized by the strategy, leading to the improper reporting of inflated losses and unfairly penalizing the strategy. This results in adjustments to the strategy's debtRatio, totalLoss, and totalDebt configurations.
+
+As a consequence, the trust placed in the strategy is adversely affected, which in turn, impacts the vault's reporting process. The calculation of credit available and debt outstanding is based on the strategy's altered parameters, leading to the incorrect allocation and deallocation of funds from the strategy.
+
+### Strategies impacted
+1) **StrategystETHAccumulator_v2**: stakes ETH on Lido Finance in order to mint stETH and accumulates ETH 2.0 staking rewards.
+2) **StrategystETHAccumulator** [[4]](#References): Previous strategy version no longer in use.
+
+### No funds loss
+
+**Funds are safe, there were no losses.**
+
+In this scenario, we have multiple mechanisms to avoid/mitigate any risk in the funds:
+
+- The harvest function is permissioned, providing controlled access.
+- In the event of an improper loss, it would be compensated as profit during the next profitable harvest.
+- Funds would be migrated before anticipating a harvest with losses.
+- A health check mechanism is implemented to reverse transactions if the profit or loss falls outside a specified range.
+
+## Details of Fix
+
+The team will implement the necessary modifications to resolve the bug and subsequently transfer the funds to the updated strategy version.
+
+## Timeline of events
+
+**April 4, 2023, 1:22 pm (UTC):** A security researcher submits a disclosure report to Immunefi.
+
+**1:42 pm:** Immunefi triages the report and classifies it as critical, escalating it to Yearn.
+
+**5:00 pm:** Yearn team begins to review all information provided in the report.
+
+**April 5th, 2023** Yearn team re-categorizes the report as "Low" and informs the Whitehat of the decision.
+
+Yearn appreciates whitehat efforts in uncovering potential vulnerabilities and is committed to rewarding all legitimate reports. Their contributions are crucial for maintaining security and fostering a transparent, robust environment for all users.
+
+## Third-Party Disclosure
+
+As per Yearn's security process document [[5]](#References), the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to this publication.
+
+## References
+
+1. https://twitter.com/0xadrii
+2. StrategystETHAccumulator_v2: https://etherscan.io/address/0x120FA5738751b275aed7F7b46B98beB38679e093#code
+3. https://stake.lido.fi
+4. StrategystETHAccumulator: https://etherscan.io/address/0x0967aFe627C732d152e3dFCAdd6f9DBfecDE18c3#code
+5. [Yearn's Security Process](https://github.com/yearn/yearn-security/blob/master/SECURITY.md)


### PR DESCRIPTION
Summary Immunefi #18604

- On April 4th 2023, a security researcher [[1]](#References) disclosed a bug in the `StrategystETHAccumulator_v2` strategy through Immunefi. **Funds are safe, there were no losses.**
- While the issue in the code had the potential to create accounting discrepancies, the vault and strategy contained multiple safeguard mechanisms that prevented the loss of funds in most instances, typically by reverting the transaction
- The impacted strategy continues to function without interruption, and a corrected contract is set to be deployed in the near future.