### PR TITLE
docs: fix duplicate 'to' typo in disclosure documents

### DIFF
--- a/disclosures/2021-02-18.md
+++ b/disclosures/2021-02-18.md
@@ -28,7 +28,7 @@ The root cause of the incident was the fee claiming action made by an external a
 
 ## Third Party Disclosure
 
-As per Yearn's security process document[[10]](#References), the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to to this publication.
+As per Yearn's security process document[[10]](#References), the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to this publication.
 
 ## References
 

--- a/disclosures/2021-04-02.md
+++ b/disclosures/2021-04-02.md
@@ -49,7 +49,7 @@ Code changes between previous and fixed Strategies[[7]](#References).
 
 ## Third Party Disclosure
 
-As per Yearn's security process document[[18]](#References), the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to to this publication.
+As per Yearn's security process document[[18]](#References), the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to this publication.
 
 ## References
 

--- a/disclosures/2021-05-13.md
+++ b/disclosures/2021-05-13.md
@@ -48,7 +48,7 @@ A short-term fix in the UI has been implemented to provide all users attempting 
 
 ## Third Party Disclosure
 
-As per Yearn's security process document[[14]](#References), the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to to this publication.
+As per Yearn's security process document[[14]](#References), the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to this publication.
 
 ## References
 

--- a/disclosures/2021-05-14.md
+++ b/disclosures/2021-05-14.md
@@ -38,7 +38,7 @@ The first `harvest` of the fixed strategy has offset the paper loss and reported
 
 ## Third Party Disclosure
 
-As per Yearn's security process document[[5]](#References), the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to to this publication.
+As per Yearn's security process document[[5]](#References), the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to this publication.
 
 ## References
 

--- a/disclosures/2021-05-20.md
+++ b/disclosures/2021-05-20.md
@@ -70,7 +70,7 @@ Following migration, the first harvest of the new strategy reported a profit of 
 
 ## Third Party Disclosures
 
-As per Yearn's security process[16], the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to to this publication.
+As per Yearn's security process[16], the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to this publication.
 
 ## References
 

--- a/disclosures/2022-11-07.md
+++ b/disclosures/2022-11-07.md
@@ -43,7 +43,7 @@ The following fixes were implemented:
 
 ## Third Party Disclosure
 
-As per Yearn's security process document[[6]](#References), the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to to this publication.
+As per Yearn's security process document[[6]](#References), the project does not currently have any established bilateral disclosure agreements. In line with our security policy, no disclosure has therefore been made to third parties prior to this publication.
 
 ## References
 


### PR DESCRIPTION
Fixed a recurring typo "prior to to this publication" → "prior to this publication" in 6 disclosure files under the `disclosures/` folder.