### PR TITLE
docs: add ytrades bricked safe disclosure

### DIFF
--- a/disclosures/2023-06-13.md
+++ b/disclosures/2023-06-13.md
@@ -1,0 +1,50 @@
+# Incident disclosure - 2023-06-13
+
+## Summary
+- The `ytrades.ychad.eth` Safe, an operational multisig used for protocol swap orders, was protected by a custom Safe guard intended to enforce that sensitive trades were executed via a private mempool.
+- The guard was deployed from a vanity address generated with Profanity. After the Profanity key-generation vulnerability became public in 2022, that deployer/governor address should have been treated as compromised infrastructure.
+- On June 13, 2023, an external actor used that ownership path to take control of the guard's governance/manager configuration, remove executor permissions, and disable the guard bypass. With no valid executor path remaining, ordinary Safe transactions failed guard checks and the Safe became inoperable.
+- Funds were not drained from the Safe. Yearn recovered approximately $569k through fulfilled CoW Swap orders using Safe EIP-1271 signatures, moving assets out without relying on the guarded Safe transaction execution path.
+
+## Background
+- [`ytrades.ychad.eth`](https://etherscan.io/address/0x7d2aB9CA511EBD6F03971Fb417d3492aA82513f0) was a Yearn operating Safe used to prepare and execute treasury and protocol swap orders. It did not custody user vault deposits.
+- [Safe guards](https://docs.safe.global/learn/safe-core/safe-core-protocol/guards) are contracts that can inspect and block Safe transactions before execution. A faulty or malicious guard configuration can therefore make a Safe unable to execute transactions, even when the Safe owners still have their signing keys.
+- The yTrades Safe used a custom [`StealthSafeGuard`](https://etherscan.io/address/0xa6A8B8F06835d44E53Ae871b2EadbE659c335e5d) to restrict execution to approved stealth/private execution infrastructure. This was intended to reduce MEV and prevent accidental public execution of sensitive trades.
+- The guard included an `overrideGuardChecks` flag. This flag was meant to temporarily bypass guard checks during setup, then be disabled after valid executors were configured.
+- The guard was deployed at a vanity address generated with Profanity. In September 2022, Profanity was publicly disclosed as vulnerable, making addresses generated with the tool unsafe to continue using for privileged roles.
+
+## Details of Incident
+- On November 13, 2021, the guard's `overrideGuardChecks` flag was set to `true`. The flag remained enabled through the June 2023 incident.
+- Because the bypass flag remained enabled, the guard was not enforcing the executor allowlist as originally intended. This was an operational control failure: the Safe appeared to have a guard in place, but the critical restriction was not active.
+- The guard's privileged deployer/governor path was tied to a Profanity-generated vanity address. Once the Profanity vulnerability was public, any continuing privileged dependency on that address created a latent compromise risk.
+- On June 13, 2023, an external actor used the privileged path to change the guard's pending governor, accept the governor role, set a pending manager, alter or clear executor permissions, and disable `overrideGuardChecks`.
+- This did not by itself transfer funds from the Safe. The main impact was bricking: with guard checks enabled and no valid executor path, normal Safe transactions could no longer succeed.
+- The incident combined two separate failures:
+  - the operational oversight that left the guard bypass enabled and masked the missing enforcement;
+  - the continued privileged use of a Profanity-derived address after the vulnerability was known.
+
+## Details of Recovery
+- Yearn avoided relying on ordinary Safe transaction execution while the guard configuration was unsafe.
+- CoW Swap supports orders signed by smart-contract wallets using [EIP-1271](https://docs.safe.global/learn/safe-core/safe-core-protocol/signatures/eip-1271). Safe owners could therefore sign offchain orders from the yTrades Safe, and the settlement path could validate the Safe signature without requiring the Safe to execute a transaction through its guard.
+- The recovery started with a small fulfilled CoW order selling 10 WETH for yvWETH on June 15, 2023. After confirming the path, Yearn submitted larger EIP-1271 orders from the same Safe and moved material balances to Yearn-controlled recovery/treasury receivers.
+- A larger WETH recovery order was fulfilled shortly after the initial test order, followed by additional fulfilled orders throughout June 15 for other available token balances.
+- This recovery path reduced the exposure without depending on the compromised guard's ability to allow a normal Safe transaction.
+- Not all value was recoverable through this path. As of May 5, 2026, the retired Safe still holds trapped assets worth approximately $174k, primarily `lp-yCRV`, `3CRV`, `yvCurve-IronBank`, `yvCurve-DOLA`, and a small ETH balance.
+- Of the nonzero ERC-20 balances remaining in the retired Safe, only `yvCurve-DOLA`, `RAI`, and `SPELL` have nonzero approvals to CoW Swap's Vault Relayer. The larger `lp-yCRV`, `3CRV`, and `yvCurve-IronBank` balances do not have CoW Swap approvals.
+- The fulfilled June 15 recovery orders sold [WETH](https://explorer.cow.fi/orders/0xeceaf26cd7a67b0477b72cbab348ff1f9e7cce69a38a2685f7917c9865cc02637d2ab9ca511ebd6f03971fb417d3492aa82513f0648ab9ff?tab=overview), [USDT](https://explorer.cow.fi/orders/0x172294b7ee5fa370ca5ca5ba47b015e2ebe133bc78991c3f9cd859a8163f64367d2ab9ca511ebd6f03971fb417d3492aa82513f0648b6aa9?tab=overview), [DAI](https://explorer.cow.fi/orders/0x81faa14794453af61c3943a4ee9261961d1de28175b6f1cfef02f5f6895cac817d2ab9ca511ebd6f03971fb417d3492aa82513f0648b6aa9?tab=overview), [yvDAI](https://explorer.cow.fi/orders/0xda08bfc2d2c126796436471c358881056478138234a1bf6430566ecac87f74b27d2ab9ca511ebd6f03971fb417d3492aa82513f0648b6aa9?tab=overview), [CRV](https://explorer.cow.fi/orders/0x68aed49c5d48849a8e4e4eca07629d9211d6a3c944cf013862dbd3b04e7753137d2ab9ca511ebd6f03971fb417d3492aa82513f0648b6aa9?tab=overview), [LDO](https://explorer.cow.fi/orders/0xe149638857db4c42cd961dd5be11704fce8bace28fbc7aa43a8ea5141a80a8f87d2ab9ca511ebd6f03971fb417d3492aa82513f0648b6aa9?tab=overview), [yvyCRV](https://explorer.cow.fi/orders/0x3b36f1cf52ea937d826eeb0ef88da9f099be49a1ff1211281f1ad8c39c8f2fb87d2ab9ca511ebd6f03971fb417d3492aa82513f0648b6aa9?tab=overview), [ALCX](https://explorer.cow.fi/orders/0xb46e63221102ea211d74e7c6b99c972d628755eb423126be4c113268fd5b43537d2ab9ca511ebd6f03971fb417d3492aa82513f0648b6aa9?tab=overview), [COW](https://explorer.cow.fi/orders/0x92d21ca6de66678bd7282902a453ba9029d7942b3d429582dd40b49e46cbc4027d2ab9ca511ebd6f03971fb417d3492aa82513f0648b6aa9?tab=overview), [yvCurve-STG-USDC](https://explorer.cow.fi/orders/0xb2c904aba4dbd9686830439574ef2f40575a4ea7a29bf22658ef0458d2ac8b5c7d2ab9ca511ebd6f03971fb417d3492aa82513f0648ca9af?tab=overview), and [SPELL](https://explorer.cow.fi/orders/0x72aa66cda18a856928058559c325c37caa7077cc1d678dd464355ad105a932d27d2ab9ca511ebd6f03971fb417d3492aa82513f0648ca9af?tab=overview). These fulfilled orders moved approximately **$568,760** in value.
+- After the recovery, the original yTrades Safe was retired with the compromised guard still installed. Yearn operations moved to a replacement Safe, [`0xC001d00d425Fa92C4F840baA8f1e0c27c4297a0B`](https://etherscan.io/address/0xC001d00d425Fa92C4F840baA8f1e0c27c4297a0B), which is now the address resolved by [`ytrades.ychad.eth`](https://app.ens.domains/ytrades.ychad.eth).
+
+## Timeline of events
+
+- **November 13, 2021 at 19:27 (UTC)** [`overrideGuardChecks` is set to `true`](https://etherscan.io/tx/0x498e4ac8ac30eea28b7ac204640ed2ec1d0578efc8faabc798f2178a5b06b28d) on the yTrades guard and remains enabled through the incident.
+- **September 15, 2022** The [Profanity vanity-address vulnerability](https://blog.1inch.io/a-vulnerability-disclosed-in-profanity-an-ethereum-vanity-address-tool/) is publicly disclosed.
+- **June 13, 2023 at 16:12 (UTC)** The guard's pending governor is changed to an externally controlled address, the governor role is accepted, and a pending manager is set through three transactions: [set pending governor](https://etherscan.io/tx/0x48869394870a14c9906ad0cae1f1fc842540c97a5d716ddc8d27ff32666bd1e1), [accept governor](https://etherscan.io/tx/0x46d94f4a4086d504c513c1dca249c6337799b063440df308103c6e18f51dd6f6), and [set pending manager](https://etherscan.io/tx/0xeb8eea5d27fee902e2aa21b70e5f20a131c849a5526acec978c27b5675ccbc9e).
+- **June 13, 2023 at 16:25 (UTC)** [Executor permissions are altered or cleared](https://ethtx.info/mainnet/0xc08bdf4cca4576cf29401a04a729e91de0014ba6b4c143a9f59aeac160fcd57a/) and `overrideGuardChecks` is disabled, rendering ordinary yTrades Safe transactions inoperable.
+- **June 15, 2023 at 03:54 (UTC)** Yearn creates and fulfills an [initial 10 WETH CoW Swap order](https://explorer.cow.fi/orders/0x418d80aee92910fb58cd9b107cee87baa5c2f6b5b6d527e39d5c922f88d4f5c17d2ab9ca511ebd6f03971fb417d3492aa82513f0648ab9ff?tab=overview) from the yTrades Safe using the Safe EIP-1271 signature path.
+- **June 15, 2023 at 04:19 (UTC)** A larger WETH recovery order is fulfilled from the [same Safe](https://explorer.cow.fi/address/0x7d2aB9CA511EBD6F03971Fb417d3492aA82513f0).
+- **June 15, 2023 from 14:18 to 18:39 (UTC)** Additional EIP-1271 CoW Swap orders move other available token balances out of the at-risk operating Safe.
+- **June 16, 2023** Yearn publishes a [technical write-up describing the recovery approach](https://paragraph.com/@yearn-finance-engineering/how-we-rescued-funds-from-a-bricked-safe-with-eip-1271).
+
+## Third Party Disclosure
+
+As per [Yearn's security process document](https://github.com/yearn/yearn-security/blob/master/SECURITY.md), the project does not currently have any established bilateral disclosure agreements. No vulnerable Yearn user-facing vault code or third-party protocol code required coordinated disclosure prior to publication. The relevant upstream facts about Profanity, Safe guards, and Safe EIP-1271 signature validation were already public.


### PR DESCRIPTION
## Summary
- add a disclosure for the June 2023 yTrades Safe bricking incident
- cover the guard bypass oversight, Profanity-derived privileged address risk, Safe bricking impact, EIP-1271 CoW Swap recovery, trapped value, and replacement Safe

## Validation
- checked against the public Yearn engineering write-up
- verified key guard state, recovery orders, current ENS/Safe state, residual balances, and CoW approvals with `cast`, CoW API, and Alchemy token balances
