### PR TITLE
feat: add age recipients for security triage

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,7 +43,9 @@ For all security-related issues, Yearn maintains the following primary points of
 | tapir   | [PGP](https://github.com/yearn/yearn-security/blob/master/keys/tapir.asc)  | [yvtapir@gmail.com](mailto:yvtapir@gmail.com) |
 | Spalen  | [PGP](https://github.com/yearn/yearn-security/blob/master/keys/spalen.asc) | [spalen@proton.me](mailto:spalen@proton.me)   |
 
-
+PGP remains the primary direct encrypted communication path. As a backup option,
+Yearn also maintains [age recipients](keys/age-recipients.txt) for active
+security triage contacts.
 
 
 ## Sending Disclosures
@@ -103,4 +105,3 @@ Additional security-related information about the Yearn project, including discl
 ## Credits
 
 Parts of this document were inspired by [Grin's security policy](https://github.com/mimblewimble/grin/blob/master/SECURITY.md).
-

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,9 +43,9 @@ For all security-related issues, Yearn maintains the following primary points of
 | tapir   | [PGP](https://github.com/yearn/yearn-security/blob/master/keys/tapir.asc)  | [yvtapir@gmail.com](mailto:yvtapir@gmail.com) |
 | Spalen  | [PGP](https://github.com/yearn/yearn-security/blob/master/keys/spalen.asc) | [spalen@proton.me](mailto:spalen@proton.me)   |
 
-PGP remains the primary direct encrypted communication path. As a backup option,
-Yearn also maintains [age recipients](keys/age-recipients.txt) for active
-security triage contacts.
+Yearn prefers [age recipients](keys/age-recipients.txt) for direct encrypted
+communication with active security triage contacts. PGP remains available as an
+alternative encrypted communication path.
 
 
 ## Sending Disclosures

--- a/keys/age-recipients.txt
+++ b/keys/age-recipients.txt
@@ -1,0 +1,10 @@
+# Yearn security triage age recipients
+
+# banteg
+age1yubikey1qdw0d67rq5clnffxe92sa8xc0093z0885nt73v4pq500nh5my03rksr8k29
+
+# spalen0
+age1yubikey1qgkt7ga72f7d4vggxn3crfrfrge9ya90fzqc0dmuj09vv6fx7gsxkgg5jpa
+
+# tapir
+age1qsewuuj8znclpy4yhk59kh6wpsgsprllawa6jpn545tjj9h4ggyqhpfjt4

--- a/keys/age-recipients.txt
+++ b/keys/age-recipients.txt
@@ -8,3 +8,6 @@ age1yubikey1qgkt7ga72f7d4vggxn3crfrfrge9ya90fzqc0dmuj09vv6fx7gsxkgg5jpa
 
 # tapir
 age1qsewuuj8znclpy4yhk59kh6wpsgsprllawa6jpn545tjj9h4ggyqhpfjt4
+
+# ctmotox2
+age1ngcevyhdxe75uzs2rhrtyfqj56t52c2h3er3l6vcl3hvl45lxgus8gl8xs


### PR DESCRIPTION
## Summary
- Add `keys/age-recipients.txt` with the collected age recipients for banteg, spalen0, tapir, and ctmotox2.
- Link the recipient file from `SECURITY.md` as the preferred direct encrypted communication path, with PGP remaining available as an alternative.

## Validation
- `git diff --check`
- `age -R keys/age-recipients.txt -o /tmp/yearn-security-age-test.age SECURITY.md`

Closes #104